### PR TITLE
Provider integration documentation fix.

### DIFF
--- a/source/rest/product-guide/index.markdown
+++ b/source/rest/product-guide/index.markdown
@@ -5187,19 +5187,20 @@ Creating a Google Directory is very similar to [creating a directory](#create-a-
 
 **Example Request**
 
-    POST https://api.stormpath.com/v1/directories?expand=provider
-    Content-Type: application/json;charset=UTF-8
-
-    {
-      "name" : "my-google-directory",
-      "description" : "A Google directory",
-      "provider": {
-        "providerId": "google"
-        "clientId":"857385-m8vk0fn2r7jmjo.apps.googleusercontent.com",
-        "clientSecret":"ehs7_-bA7OWQSQ4",
-        "redirectUri":"https://myapplication.com/authenticate"
-      }
-    }
+    curl -X POST --user $YOUR_API_KEY_ID:$YOUR_API_KEY_SECRET \
+         -H "Accept: application/json" \
+         -H "Content-Type: application/json" \
+         -d '{
+              "name" : "my-google-directory",
+              "description" : "A Google directory",
+              "provider": {
+                "providerId": "google",
+                "clientId":"857385-m8vk0fn2r7jmjo.apps.googleusercontent.com",
+                "clientSecret":"ehs7_-bA7OWQSQ4",
+                "redirectUri":"https://myapplication.com/authenticate"
+              }
+            }' \
+     "https://api.stormpath.com/v1/directories?expand=provider"
 
 **Example Response**
 
@@ -5249,15 +5250,16 @@ The following is how you use `providerData` to get an `Account` for a given auth
 
 **Example Request**
 
-    POST https://api.stormpath.com/v1/applications/24mp4us71ntza6lBwlu/accounts
-    Content-Type: application/json;charset=UTF-8
-
-    {
-      providerData: { 
-        "providerId": "google",
-        "code": "4/2Dz0r7r9oNBE9dFD-_JUb.suCu7uj8TEnp6UAPm0"
-      }
-    }
+    curl -X POST --user $YOUR_API_KEY_ID:$YOUR_API_KEY_SECRET \
+         -H "Accept: application/json" \
+         -H "Content-Type: application/json" \
+         -d '{
+                "providerData": {
+                  "providerId": "google",
+                  "code": "4/2Dz0r7r9oNBE9dFD-_JUb.suCu7uj8TEnp6UAPm0"
+                }
+              }' \
+     "https://api.stormpath.com/v1/applications/24mp4us71ntza6lBwlu/accounts"
 
 **Example Response**
 


### PR DESCRIPTION
I've been working on the facebook/google integration and have found a few minor mistakes with the format of requests and responses for that part in the REST documentation.

There were some places that were missing quotation marks or commas, and basically I modified requests to be CURL-friendly. One thing i absolutely love about the stormpath REST documentation is the part where requests are written as CURL requests. Then I can just easily copy paste them into my terminal and run them before I start working on new features in the Ruby SDK.

Also, there was a mistake with the request for creating a new facebook directory. It's url didn't hold an 'expand=provider' query string, but the response had a an expanded provider resource. On the other hand, the google one was okay. If you wish to have them both expanded, or not, i can modify this pull request to reflect that.
