### PR TITLE
Removing Express Quickstarts (for now).

### DIFF
--- a/source/nodejs/index.markdown
+++ b/source/nodejs/index.markdown
@@ -36,7 +36,6 @@ content_top: [docs_top.html]
             <div class="row">
               <div class="col-sm-12 visible-sm">
                 <ul class="fa-ul">
-                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}
@@ -47,7 +46,6 @@ content_top: [docs_top.html]
               </div>
               <div class="col-md-6 hidden-sm">
                 <ul class="fa-ul">
-                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}

--- a/source/nodejs/index.markdown
+++ b/source/nodejs/index.markdown
@@ -41,7 +41,7 @@ content_top: [docs_top.html]
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}
                   <li><i class="fa-li fa fa-github"></i><a href="https://github.com/stormpath/stormpath-sdk-express">Project on GitHub</a></li>
                   <li><i class="fa-li fa fa-pencil"></i><a href="https://stormpath.com/blog/build-nodejs-express-stormpath-app/">Webapp Tutorial</a></li>
-                  <li><i class="fa-li fa fa-pencil"></i><a href="/nodejs/express/product.html#api-authentication">API Authentication Tutorial</a></li>
+                  <li><i class="fa-li fa fa-pencil"></i><a href="/nodejs/express/latest/authentication.html#api-authentication-basic-auth">API Authentication Tutorial</a></li>
                 </ul>
               </div>
               <div class="col-md-6 hidden-sm">

--- a/source/nodejs/index.markdown
+++ b/source/nodejs/index.markdown
@@ -36,6 +36,7 @@ content_top: [docs_top.html]
             <div class="row">
               <div class="col-sm-12 visible-sm">
                 <ul class="fa-ul">
+                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}
@@ -46,6 +47,7 @@ content_top: [docs_top.html]
               </div>
               <div class="col-md-6 hidden-sm">
                 <ul class="fa-ul">
+                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}

--- a/source/nodejs/index.markdown
+++ b/source/nodejs/index.markdown
@@ -36,7 +36,7 @@ content_top: [docs_top.html]
             <div class="row">
               <div class="col-sm-12 visible-sm">
                 <ul class="fa-ul">
-                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
+                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/latest/setup.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}
@@ -47,7 +47,7 @@ content_top: [docs_top.html]
               </div>
               <div class="col-md-6 hidden-sm">
                 <ul class="fa-ul">
-                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/quickstart.html">Quickstart</a></li>
+                  <li><i class="fa-li fa fa-car"></i><a href="/nodejs/express/latest/setup.html">Quickstart</a></li>
                   <li><i class="fa-li fa fa-book"></i><a href="/nodejs/express/index.html">Documentation</a></li>
                   <li><i class="fa-li fa fa-code"></i><a href="https://stormpath.com/blog/making-expressjs-authentication-fun-again/">Example Application</a></li>
                   {% comment %}<li><i class="fa-li fa fa-file-text"></i><a href="#">API Reference</a></li>{% endcomment %}

--- a/source/nodejs/index.markdown
+++ b/source/nodejs/index.markdown
@@ -55,7 +55,7 @@ content_top: [docs_top.html]
                 <ul class="fa-ul">
                   <li><i class="fa-li fa fa-github"></i><a href="https://github.com/stormpath/stormpath-sdk-express">Project on GitHub</a></li>
                   <li><i class="fa-li fa fa-pencil"></i><a href="https://stormpath.com/blog/build-nodejs-express-stormpath-app/">Webapp Tutorial</a></li>
-                  <li><i class="fa-li fa fa-pencil"></i><a href="/nodejs/express/product.html#api-authentication">API Authentication Tutorial</a></li>
+                  <li><i class="fa-li fa fa-pencil"></i><a href="/nodejs/express/latest/authentication.html#api-authentication-basic-auth">API Authentication Tutorial</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Our new docs don't have these, so I'm removing the links temporarily until we
get them.