### PR TITLE
Remove prerelease tag from aspnet

### DIFF
--- a/source/_layouts/dotnetpage.html
+++ b/source/_layouts/dotnetpage.html
@@ -123,7 +123,7 @@
                       <h2>ASP.NET 4.5+</h2>
                     </div>
                     <div class="example-text">
-                      $ install-package -pre Stormpath.AspNet
+                      $ install-package Stormpath.AspNet
                     </div>
                     <div class="two-boxes-blc">
                       <div class="row">


### PR DESCRIPTION
The ASP.NET integration is no longer beta/prerelease. 🎉 

(This was true a while ago, I just didn't notice this until now)